### PR TITLE
Replace pokemon schema with tools

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "setup": "node setup.js"
+    "setup": "node setup.js",
+    "seed": "node seed_tools.js"
   },
   "keywords": [],
   "author": "",

--- a/server/seed_tools.js
+++ b/server/seed_tools.js
@@ -1,0 +1,47 @@
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString: 'postgres://iosuser:secret@localhost:5432/iosdb'
+});
+
+async function seed() {
+  const tools = [
+    { name: 'Hammer', price: 25, description: 'Standard claw hammer' },
+    { name: 'Screwdriver', price: 10, description: 'Flat head screwdriver' },
+    { name: 'Wrench', price: 15, description: 'Adjustable wrench' },
+    { name: 'Pliers', price: 12, description: 'Needle nose pliers' },
+    { name: 'Saw', price: 20, description: 'Hand saw for wood' },
+    { name: 'Drill', price: 80, description: 'Cordless power drill' },
+    { name: 'Sander', price: 45, description: 'Electric orbital sander' },
+    { name: 'Chisel', price: 18, description: 'Wood chisel set' },
+    { name: 'Tape Measure', price: 8, description: '25-foot tape measure' },
+    { name: 'Level', price: 14, description: '24-inch bubble level' },
+    { name: 'Utility Knife', price: 9, description: 'Retractable utility knife' },
+    { name: 'Flashlight', price: 16, description: 'LED work flashlight' },
+    { name: 'Ladder', price: 120, description: '6-foot step ladder' },
+    { name: 'Crowbar', price: 22, description: 'Heavy duty crowbar' },
+    { name: 'Socket Set', price: 55, description: 'Metric socket set' },
+    { name: 'Stud Finder', price: 30, description: 'Electronic stud finder' },
+    { name: 'Wire Stripper', price: 13, description: 'Automatic wire stripper' },
+    { name: 'Paint Brush', price: 7, description: '2-inch paint brush' },
+    { name: 'Welding Mask', price: 65, description: 'Auto-darkening welding mask' },
+    { name: 'Air Compressor', price: 150, description: 'Portable air compressor' }
+  ];
+
+  for (const tool of tools) {
+    await pool.query(
+      'INSERT INTO tools (name, price, description, owner_id) VALUES ($1, $2, $3, $4)',
+      [tool.name, tool.price, tool.description, 1]
+    );
+  }
+}
+
+seed()
+  .then(() => {
+    console.log('Tools seeded');
+    pool.end();
+  })
+  .catch(err => {
+    console.error(err);
+    pool.end();
+  });

--- a/server/setup.js
+++ b/server/setup.js
@@ -4,90 +4,31 @@ const pool = new Pool({
   connectionString: 'postgres://iosuser:secret@localhost:5432/iosdb'
 });
 
-async function createTables() {
+async function setup() {
+  await pool.query('DROP TABLE IF EXISTS pokemon_stat CASCADE');
+  await pool.query('DROP TABLE IF EXISTS pokemon_type CASCADE');
+  await pool.query('DROP TABLE IF EXISTS pokemon_move CASCADE');
+  await pool.query('DROP TABLE IF EXISTS pokemon_ability CASCADE');
+  await pool.query('DROP TABLE IF EXISTS pokemon CASCADE');
+  await pool.query('DROP TABLE IF EXISTS stat CASCADE');
+  await pool.query('DROP TABLE IF EXISTS type CASCADE');
+  await pool.query('DROP TABLE IF EXISTS move CASCADE');
+  await pool.query('DROP TABLE IF EXISTS ability CASCADE');
+
   await pool.query(`
-    CREATE TABLE IF NOT EXISTS pokemon (
+    CREATE TABLE IF NOT EXISTS tools (
       id SERIAL PRIMARY KEY,
       name TEXT NOT NULL UNIQUE,
-      base_experience INTEGER,
-      height INTEGER,
-      weight INTEGER,
-      is_default BOOLEAN,
-      order_num INTEGER
-    );
-  `);
-
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS ability (
-      id SERIAL PRIMARY KEY,
-      name TEXT NOT NULL UNIQUE
-    );
-  `);
-
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS pokemon_ability (
-      pokemon_id INTEGER REFERENCES pokemon(id) ON DELETE CASCADE,
-      ability_id INTEGER REFERENCES ability(id) ON DELETE CASCADE,
-      is_hidden BOOLEAN,
-      slot INTEGER,
-      PRIMARY KEY (pokemon_id, ability_id)
-    );
-  `);
-
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS move (
-      id SERIAL PRIMARY KEY,
-      name TEXT NOT NULL UNIQUE
-    );
-  `);
-
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS pokemon_move (
-      pokemon_id INTEGER REFERENCES pokemon(id) ON DELETE CASCADE,
-      move_id INTEGER REFERENCES move(id) ON DELETE CASCADE,
-      method TEXT,
-      level INTEGER,
-      PRIMARY KEY (pokemon_id, move_id)
-    );
-  `);
-
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS type (
-      id SERIAL PRIMARY KEY,
-      name TEXT NOT NULL UNIQUE
-    );
-  `);
-
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS pokemon_type (
-      pokemon_id INTEGER REFERENCES pokemon(id) ON DELETE CASCADE,
-      type_id INTEGER REFERENCES type(id) ON DELETE CASCADE,
-      slot INTEGER,
-      PRIMARY KEY (pokemon_id, type_id)
-    );
-  `);
-
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS stat (
-      id SERIAL PRIMARY KEY,
-      name TEXT NOT NULL UNIQUE
-    );
-  `);
-
-  await pool.query(`
-    CREATE TABLE IF NOT EXISTS pokemon_stat (
-      pokemon_id INTEGER REFERENCES pokemon(id) ON DELETE CASCADE,
-      stat_id INTEGER REFERENCES stat(id) ON DELETE CASCADE,
-      base_stat INTEGER,
-      effort INTEGER,
-      PRIMARY KEY (pokemon_id, stat_id)
+      price NUMERIC,
+      description TEXT,
+      owner_id INTEGER
     );
   `);
 }
 
-createTables()
+setup()
   .then(() => {
-    console.log('Tables created');
+    console.log('Tables updated');
     pool.end();
   })
   .catch(err => {


### PR DESCRIPTION
## Summary
- drop all pokemon tables in `setup.js`
- create a new `tools` table
- seed the `tools` table with 20 sample entries
- expose `seed` script in package.json

## Testing
- `npm run setup` *(fails: Cannot find module 'pg')*
- `npm run seed` *(fails: Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_b_683a477b5d2483289cb748165545ce83