### PR TITLE
Implement tool CRUD endpoints

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -44,4 +44,88 @@ app.get('/users', async (req, res) => {
   }
 });
 
+// List all tools
+app.get('/tools', async (req, res) => {
+  try {
+    const result = await pool.query('SELECT * FROM tools');
+    res.send(result.rows);
+  } catch (err) {
+    res.status(500).send({ error: err.message });
+  }
+});
+
+// Get a tool by name
+app.get('/tools/name/:name', async (req, res) => {
+  const { name } = req.params;
+  try {
+    const result = await pool.query('SELECT * FROM tools WHERE name = $1', [name]);
+    if (!result.rows.length) {
+      return res.status(404).send({ error: 'Tool not found' });
+    }
+    res.send(result.rows[0]);
+  } catch (err) {
+    res.status(500).send({ error: err.message });
+  }
+});
+
+// Get a tool by id
+app.get('/tools/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query('SELECT * FROM tools WHERE id = $1', [id]);
+    if (!result.rows.length) {
+      return res.status(404).send({ error: 'Tool not found' });
+    }
+    res.send(result.rows[0]);
+  } catch (err) {
+    res.status(500).send({ error: err.message });
+  }
+});
+
+// Create a new tool
+app.post('/tools', async (req, res) => {
+  const { name, price, description, owner_id } = req.body;
+  try {
+    const result = await pool.query(
+      'INSERT INTO tools (name, price, description, owner_id) VALUES ($1, $2, $3, $4) RETURNING *',
+      [name, price, description, owner_id]
+    );
+    res.status(201).send(result.rows[0]);
+  } catch (err) {
+    res.status(400).send({ error: err.message });
+  }
+});
+
+// Update an existing tool
+app.put('/tools/:id', async (req, res) => {
+  const { id } = req.params;
+  const { name, price, description, owner_id } = req.body;
+  try {
+    const result = await pool.query(
+      'UPDATE tools SET name = $1, price = $2, description = $3, owner_id = $4 WHERE id = $5 RETURNING *',
+      [name, price, description, owner_id, id]
+    );
+    if (!result.rows.length) {
+      return res.status(404).send({ error: 'Tool not found' });
+    }
+    res.send(result.rows[0]);
+  } catch (err) {
+    res.status(400).send({ error: err.message });
+  }
+});
+
+// Delete a tool
+app.delete('/tools/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query('DELETE FROM tools WHERE id = $1', [id]);
+    if (result.rowCount === 0) {
+      return res.status(404).send({ error: 'Tool not found' });
+    }
+    res.status(204).send();
+  } catch (err) {
+    res.status(400).send({ error: err.message });
+  }
+});
+
 app.listen(3000, () => console.log('Server running on port 3000'));


### PR DESCRIPTION
## Summary
- add tool CRUD routes to the backend server
- fetch a tool by its name or by id

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683a49b599848328858ace368fd3a08c