### PR TITLE
Add API documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,144 @@
+# API Documentation
+
+This document outlines the REST API endpoints exposed by the server in the `server/` directory. The application uses JSON for request and response bodies and listens on port `3000` by default.
+
+## Authentication
+Some endpoints require a valid JSON Web Token (JWT). Clients should include the token in the `Authorization` header using the `Bearer <token>` scheme.
+
+---
+
+## Endpoints
+
+### `POST /signup`
+Create a new user account.
+
+**Request Body**
+```json
+{
+  "username": "string",
+  "password": "string"
+}
+```
+
+**Responses**
+- `201 Created` – user record created.
+- `4xx` – on validation failure.
+
+---
+
+### `POST /login`
+Authenticate a user and receive a JWT.
+
+**Request Body**
+```json
+{
+  "username": "string",
+  "password": "string"
+}
+```
+
+**Responses**
+- `200 OK` – `{ "token": "<jwt>" }` on success.
+- `401 Unauthorized` – when credentials are invalid.
+
+---
+
+### `GET /users`
+Retrieve a list of users. Requires a valid JWT.
+
+**Headers**
+```
+Authorization: Bearer <token>
+```
+
+**Responses**
+- `200 OK` – array of users, each with `id` and `username`.
+- `401 Unauthorized` – when the token is missing or invalid.
+
+---
+
+### `GET /tools`
+Return all tools in the database.
+
+**Responses**
+- `200 OK` – array of tool objects.
+- `500 Internal Server Error` – on database errors.
+
+---
+
+### `GET /tools/name/:name`
+Fetch a tool by its `name` field.
+
+**URL Parameters**
+- `name` – string name of the tool.
+
+**Responses**
+- `200 OK` – tool object.
+- `404 Not Found` – when no matching tool exists.
+- `500 Internal Server Error` – on database errors.
+
+---
+
+### `GET /tools/:id`
+Fetch a tool by its numeric `id`.
+
+**URL Parameters**
+- `id` – numeric tool identifier.
+
+**Responses**
+- `200 OK` – tool object.
+- `404 Not Found` – when no matching tool exists.
+- `500 Internal Server Error` – on database errors.
+
+---
+
+### `POST /tools`
+Create a new tool.
+
+**Request Body**
+```json
+{
+  "name": "string",
+  "price": 0,
+  "description": "string",
+  "owner_id": 0
+}
+```
+
+**Responses**
+- `201 Created` – newly created tool object.
+- `400 Bad Request` – on validation or database errors.
+
+---
+
+### `PUT /tools/:id`
+Update an existing tool.
+
+**URL Parameters**
+- `id` – numeric tool identifier.
+
+**Request Body** Same fields as in `POST /tools`.
+
+**Responses**
+- `200 OK` – updated tool object.
+- `404 Not Found` – when the tool does not exist.
+- `400 Bad Request` – on validation or database errors.
+
+---
+
+### `DELETE /tools/:id`
+Remove a tool from the database.
+
+**URL Parameters**
+- `id` – numeric tool identifier.
+
+**Responses**
+- `204 No Content` – on successful deletion.
+- `404 Not Found` – when the tool does not exist.
+- `400 Bad Request` – on database errors.
+
+---
+
+## Error Responses
+Every endpoint returns a JSON object containing an `error` field when a request fails. The message provides a short description of the problem.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # starter_ios_app_backend
+
+This repository contains a simple Node.js/Express server with a few example endpoints. The server uses PostgreSQL for persistence and exposes a small set of user and tool management APIs.
+
+See [API.md](API.md) for a full description of all available endpoints.


### PR DESCRIPTION
## Summary
- document all available endpoints
- link to API docs from README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683a4f72531083288f70085fea26e9d6