### PR TITLE
Add chats table and update tool schema

### DIFF
--- a/API.md
+++ b/API.md
@@ -95,6 +95,8 @@ Fetch a tool by its numeric `id`.
 ### `POST /tools`
 Create a new tool.
 
+Tool names do not need to be unique. The `owner_id` field should reference an existing user.
+
 **Request Body**
 ```json
 {
@@ -136,6 +138,32 @@ Remove a tool from the database.
 - `204 No Content` – on successful deletion.
 - `404 Not Found` – when the tool does not exist.
 - `400 Bad Request` – on database errors.
+
+---
+
+### `GET /chats`
+Retrieve all chat messages.
+
+**Responses**
+- `200 OK` – array of chat objects.
+- `500 Internal Server Error` – on database errors.
+
+---
+
+### `POST /chats`
+Create a new chat message.
+
+**Request Body**
+```json
+{
+  "user_id": 0,
+  "message": "string"
+}
+```
+
+**Responses**
+- `201 Created` – newly created chat object.
+- `400 Bad Request` – on validation or database errors.
 
 ---
 

--- a/server/index.js
+++ b/server/index.js
@@ -128,4 +128,28 @@ app.delete('/tools/:id', async (req, res) => {
   }
 });
 
+// List all chat messages
+app.get('/chats', async (req, res) => {
+  try {
+    const result = await pool.query('SELECT * FROM chats ORDER BY created_at');
+    res.send(result.rows);
+  } catch (err) {
+    res.status(500).send({ error: err.message });
+  }
+});
+
+// Create a new chat message
+app.post('/chats', async (req, res) => {
+  const { user_id, message } = req.body;
+  try {
+    const result = await pool.query(
+      'INSERT INTO chats (user_id, message) VALUES ($1, $2) RETURNING *',
+      [user_id, message]
+    );
+    res.status(201).send(result.rows[0]);
+  } catch (err) {
+    res.status(400).send({ error: err.message });
+  }
+});
+
 app.listen(3000, () => console.log('Server running on port 3000'));

--- a/server/setup.js
+++ b/server/setup.js
@@ -14,14 +14,37 @@ async function setup() {
   await pool.query('DROP TABLE IF EXISTS type CASCADE');
   await pool.query('DROP TABLE IF EXISTS move CASCADE');
   await pool.query('DROP TABLE IF EXISTS ability CASCADE');
+  await pool.query('DROP TABLE IF EXISTS chats CASCADE');
+  await pool.query('DROP TABLE IF EXISTS tools CASCADE');
+  await pool.query('DROP TABLE IF EXISTS users CASCADE');
 
+  // Create basic users table used for authentication
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS users (
+      id SERIAL PRIMARY KEY,
+      username TEXT UNIQUE NOT NULL,
+      password TEXT NOT NULL
+    );
+  `);
+
+  // Tools no longer enforce unique names and now reference the users table
   await pool.query(`
     CREATE TABLE IF NOT EXISTS tools (
       id SERIAL PRIMARY KEY,
-      name TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
       price NUMERIC,
       description TEXT,
-      owner_id INTEGER
+      owner_id INTEGER REFERENCES users(id)
+    );
+  `);
+
+  // Table for storing chat messages
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS chats (
+      id SERIAL PRIMARY KEY,
+      user_id INTEGER REFERENCES users(id),
+      message TEXT NOT NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
   `);
 }


### PR DESCRIPTION
## Summary
- remove unique constraint from `tools.name`
- relate `tools.owner_id` to `users.id`
- create new `chats` table
- document new chat endpoints
- implement simple chat GET and POST endpoints

## Testing
- `npm run setup` *(fails: Cannot find module 'pg')*

------
https://chatgpt.com/codex/tasks/task_b_683a6adda00c8328b3436b3ff935d674