### PR TITLE
Include owner info on tool listing

### DIFF
--- a/API.md
+++ b/API.md
@@ -58,10 +58,11 @@ Authorization: Bearer <token>
 ---
 
 ### `GET /tools`
-Return all tools in the database.
+Return all tools in the database. Each tool object includes an
+`owner_username` field from the user who owns the tool.
 
 **Responses**
-- `200 OK` – array of tool objects.
+- `200 OK` – array of tool objects, each with owner information.
 - `500 Internal Server Error` – on database errors.
 
 ---

--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,11 @@ app.get('/users', async (req, res) => {
 // List all tools
 app.get('/tools', async (req, res) => {
   try {
-    const result = await pool.query('SELECT * FROM tools');
+    const result = await pool.query(
+      `SELECT tools.*, users.username AS owner_username
+       FROM tools
+       JOIN users ON tools.owner_id = users.id`
+    );
     res.send(result.rows);
   } catch (err) {
     res.status(500).send({ error: err.message });


### PR DESCRIPTION
## Summary
- join `users` when listing tools
- document new `owner_username` field returned by `/tools`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_683a9ae17e5083288026401340857458